### PR TITLE
Use latest blake3 version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/iron-fish/ironfish"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake3 = "1.3.1"
+blake3 = "1.5.0"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }


### PR DESCRIPTION
It looks like latest blake3 version (1.5.0) is already specified in the Cargo.lock but just adding it explicitly to Cargo.toml for consisntency

